### PR TITLE
chore: upgrade WireMock.Net to 2.12.0 Minimal, fix 14 Dependabot alerts

### DIFF
--- a/test/UptimeRobotDotNetTests/UptimeRobotDotNetTests.csproj
+++ b/test/UptimeRobotDotNetTests/UptimeRobotDotNetTests.csproj
@@ -21,7 +21,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
-		<PackageReference Include="WireMock.Net" Version="1.8.0" />
+		<PackageReference Include="WireMock.Net.Minimal" Version="2.12.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary

Upgrades `WireMock.Net` 1.8.0 → `WireMock.Net.Minimal` 2.12.0 in the test project to resolve all 14 open Dependabot security alerts.

## Background

All 14 alerts were **transitive** dependencies pulled in through `WireMock.Net 1.8.0` (test-only). The source library `src/UptimeRobotDotnet.csproj` has no Scriban/OpenApi dependency, so these vulnerabilities did not ship to package consumers — but they should still be resolved to keep the alert queue clean and the test dependencies current.

## What changed

Single line in `test/UptimeRobotDotNetTests/UptimeRobotDotNetTests.csproj`:

```diff
-<PackageReference Include="WireMock.Net" Version="1.8.0" />
+<PackageReference Include="WireMock.Net.Minimal" Version="2.12.0" />
```

This transitively upgrades:
- **Scriban.Signed** 5.5.0 → 7.2.5 (resolves 13 alerts)
- **Microsoft.OpenApi** 2.0.0-preview.16 → patched via WireMock.Net.OpenApiParser 2.12.0 (resolves 1 alert)

## Alerts resolved

| # | GHSA | Severity | Package |
|---|------|----------|---------|
| 10 | GHSA-5wr9-m6jw-xx44 | Critical | Scriban.Signed |
| 9 | GHSA-x6m9-38vm-2xhf | High | Scriban.Signed |
| 1 | GHSA-24c8-4792-22hx | High | Scriban.Signed |
| 3 | GHSA-c875-h985-hvrc | High | Scriban.Signed |
| 5 | GHSA-wgh7-7m3c-fx25 | High | Scriban.Signed |
| 6 | GHSA-grr9-747v-xvcp | High | Scriban.Signed |
| 8 | GHSA-p6q4-fgr8-vx4p | High | Scriban.Signed |
| 11 | GHSA-v66j-x4hw-fv9g | High | Scriban.Signed |
| 12 | GHSA-xcx6-vp38-8hr5 | High | Scriban.Signed |
| 2 | GHSA-v5pm-xwqc-g5wc (CVE-2026-49451) | High | Microsoft.OpenApi |
| 4 | GHSA-q6rr-fm2g-g5x8 | Medium | Scriban.Signed |
| 7 | GHSA-5rpf-x9jg-8j5p | Medium | Scriban.Signed |
| 13 | GHSA-m2p3-hwv5-xpqw | Medium | Scriban.Signed |
| 14 | GHSA-xw6w-9jjh-p9cr | Medium | Scriban.Signed |

## Why Minimal?

The full `WireMock.Net` meta-package bundles `WireMock.Net.Minimal` plus GraphQL, ProtoBuf, OpenTelemetry, MimePart, and SystemTextJsonPath matcher modules. The test suite only uses the core HTTP mocking API (`WireMockServer`, `Request.Create`, `Response.Create`, `Server.CreateClient`), so the Minimal package is a cleaner fit with a lighter dependency footprint.

## Verification

- ✅ Build succeeds (0 errors; 6 pre-existing nullability warnings in MonitorsManualTests.cs, unrelated)
- ✅ All 52 tests pass on net10.0
- ✅ `dotnet list package --include-transitive` shows zero NU1902/NU1903/NU1904 warnings
- ✅ Transitive versions: Scriban.Signed 7.2.5, RamlToOpenApiConverter.SourceOnly 0.21.0