### PR TITLE
chore: bump NUnit 4.4.0 → 4.5.0 and NUnit3TestAdapter 6.0.1 → 6.1.0

### DIFF
--- a/test/UptimeRobotDotNetTests/UptimeRobotDotNetTests.csproj
+++ b/test/UptimeRobotDotNetTests/UptimeRobotDotNetTests.csproj
@@ -15,12 +15,12 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-		<PackageReference Include="NUnit" Version="4.4.0" />
+		<PackageReference Include="NUnit" Version="4.5.0" />
 		<PackageReference Include="NUnit.Analyzers" Version="4.11.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
+		<PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
 		<PackageReference Include="WireMock.Net.Minimal" Version="2.12.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Summary

Consolidates the two remaining Dependabot PRs (#38, #39) that conflicted with main after the WireMock.Net.Minimal upgrade (#40) and other dependency bumps were merged.

## Changes

Bumps in `test/UptimeRobotDotNetTests/UptimeRobotDotNetTests.csproj`:
- `NUnit` 4.4.0 → 4.5.0 (from #38)
- `NUnit3TestAdapter` 6.0.1 → 6.1.0 (from #39)

## Verification

- ✅ Build succeeds (0 errors)
- ✅ All 52 tests pass on net10.0

## Related

- Closes #38
- Closes #39